### PR TITLE
chore: bump version to 0.5.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tavily/n8n-nodes-tavily",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@tavily/n8n-nodes-tavily",
-      "version": "0.5.1",
+      "version": "0.5.2",
       "license": "MIT",
       "devDependencies": {
         "@typescript-eslint/parser": "~8.54",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tavily/n8n-nodes-tavily",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "description": "A community node for n8n to integrate Tavily API for web search and content extraction.",
   "keywords": [
     "n8n-community-node-package"


### PR DESCRIPTION
## Summary

Bumps `@tavily/n8n-nodes-tavily` from `0.5.1` → `0.5.2` so the `exact_match` parameter added in #57 can be published to npm.

## Context

- #57 added the `exact_match` boolean option to the search `queryOptions` collection. Reviewed and verified working end-to-end in a local n8n against the merged-main build — toggling `exact_match` on changes the API's normalized query (quotes preserved) and the result set (e.g. Wikipedia becomes the top result for `"Dario Amodei" "Anthropic"`).
- `0.5.1` is the current latest on npm, so `npm publish` on main would fail without this bump.

## After merge

Publishing is still manual in this repo (no CI publish workflow):

```bash
git pull && npm publish --access public
git tag v0.5.2 && git push --tags
```

## Follow-ups worth tracking separately

Discovered while testing locally — **none are regressions from #57**, but they affect anyone doing local dev against the package's own `node_modules`:

1. `n8n-workflow` 2.7.0 renamed `NodeConnectionType` → `NodeConnectionTypes` (plural). The current TS source imports the old singular name; works when the package resolves `n8n-workflow` from a host n8n install (1.x semantics preserved), fails when resolved from this repo's own `node_modules`.
2. TypeScript 4.8's mixed value/type import elision dropped the entire `import { NodeConnectionType, type INodeTypeDescription } from 'n8n-workflow'` statement from the compiled JS — even the value import got erased.
3. Repo has no CI (`.github/workflows/` is empty). Adding a minimal build+lint workflow would have caught both of the above before #57 landed.